### PR TITLE
Remove Support for Negative Balances

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,20 +1,21 @@
 name: run-tests
 run-name: ${{ github.event_name }}-${{ github.actor }}-${{ github.run_number }}
 on:
-  push
-  pull_request
+  push:
+  pull_request:
 
 jobs:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v4
-    - name: Setup Go 1.24.x
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.24.x'
-    - name: Tidy Go Dependencies
-      run: go mod tidy
-    - name: Build Go Project
-      run: make Build
-    - name: Run Go Tests
-      run: make test
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go 1.24.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.x'
+      - name: Tidy Go Dependencies
+        run: go mod tidy
+      - name: Build Go Project
+        run: make build
+      - name: Run Go Tests
+        run: make test

--- a/circuit/circuit_test.go
+++ b/circuit/circuit_test.go
@@ -1,11 +1,12 @@
 package circuit
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/test"
-	"math/big"
-	"testing"
 )
 
 const count = 16
@@ -31,22 +32,6 @@ func TestCircuitWorks(t *testing.T) {
 	assert.ProverSucceeded(baseCircuit, &c, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16))
 }
 
-func TestCircuitDoesNotAcceptNegativeAccounts(t *testing.T) {
-	assert := test.NewAssert(t)
-
-	var c Circuit
-	goAccounts, _, _, _ := GenerateTestData(count, 0)
-	goAccounts[0].Balance.Bitcoin = *big.NewInt(-1)
-	c.Accounts = ConvertGoAccountsToAccounts(goAccounts)
-	goAssetSum := SumGoAccountBalancesIncludingNegatives(goAccounts)
-	c.AssetSum = ConvertGoBalanceToBalance(goAssetSum)
-	merkleRoot := GoComputeMerkleRootFromAccounts(goAccounts)
-	c.MerkleRoot = merkleRoot
-	c.MerkleRootWithAssetSumHash = GoComputeMiMCHashForAccount(GoAccount{merkleRoot, goAssetSum})
-
-	assert.ProverFailed(baseCircuit, &c, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16))
-}
-
 func TestCircuitDoesNotAcceptAccountsWithOverflow(t *testing.T) {
 	assert := test.NewAssert(t)
 
@@ -58,7 +43,7 @@ func TestCircuitDoesNotAcceptAccountsWithOverflow(t *testing.T) {
 	}
 	goAccounts[0].Balance.Bitcoin = *new(big.Int).SetBytes(amt)
 	c.Accounts = ConvertGoAccountsToAccounts(goAccounts)
-	goAssetSum := SumGoAccountBalancesIncludingNegatives(goAccounts)
+	goAssetSum := SumGoAccountBalances(goAccounts)
 	c.AssetSum = ConvertGoBalanceToBalance(goAssetSum)
 	merkleRoot := GoComputeMerkleRootFromAccounts(goAccounts)
 	c.MerkleRoot = merkleRoot


### PR DESCRIPTION
Removed support for negative balances from the repo - the main reason is because negative numbers are not even internally supported by the constraint system (since it only has values from a finite field with a modulus). Moreover, even if we sign extend negative balances to test to make sure they fail the circuit, its equivalent to testing if they fail the range checks on the circuit due to overflow (since sign extended negative numbers consist of much more than 64 bits in this case). We are already testing this. Thus, support for negative numbers is completely unnecessary.

Ticket: BTC-2148