### PR TITLE
Add long user id support

### DIFF
--- a/circuit/utils.go
+++ b/circuit/utils.go
@@ -1,10 +1,9 @@
 package circuit
 
 import (
-	"crypto/rand"
 	"fmt"
 	"math/big"
-	mathrand "math/rand"
+	"math/rand"
 	"strings"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -240,23 +239,19 @@ func SumGoAccountBalances(accounts []GoAccount) GoBalance {
 func GenerateTestData(count int, seed int) (accounts []GoAccount, assetSum GoBalance, merkleRoot []byte, merkleRootWithAssetSumHash []byte) {
 
 	// initialize random number generator with seed
-	source := mathrand.NewSource(int64(seed))
-	rng := mathrand.New(source)
+	source := rand.NewSource(int64(seed))
+	rng := rand.New(source)
 
 	for i := 0; i < count; i++ {
-		// generate random user ID (16 bytes)
-		userId := make([]byte, 16)
-		_, err := rand.Read(userId)
-		if err != nil {
-			// fallback to deterministic ID if random generation fails
-			userId = []byte(fmt.Sprintf("user_%d_%d", i, seed))
-		}
+		// generate random user ID
+		userId := convertRawUserIdToBytes(fmt.Sprintf("user%d", rng.Int31()))
 
+		// generate random balances between 0 and 10,500
 		balances := make(GoBalance, GetNumberOfAssets())
 		for i := range balances {
-			// generate random balances between 0 and 10,500
 			balances[i] = big.NewInt(rng.Int63n(10500))
 		}
+
 		accounts = append(accounts, GoAccount{UserId: userId, Balance: balances})
 	}
 	goAccountBalanceSum := SumGoAccountBalances(accounts)

--- a/core/generator.go
+++ b/core/generator.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"bitgo.com/proof_of_reserves/circuit"
 	"strconv"
+
+	"bitgo.com/proof_of_reserves/circuit"
 )
 
 func writeTestDataToFile(batchCount int, countPerBatch int) {
@@ -13,7 +14,7 @@ func writeTestDataToFile(batchCount int, countPerBatch int) {
 		var assetSum circuit.GoBalance
 		secretData.Accounts, assetSum, secretData.MerkleRoot, secretData.MerkleRootWithAssetSumHash = circuit.GenerateTestData(countPerBatch, i+11)
 		secretData.AssetSum = &assetSum
-		err := writeJson(filePath, secretData)
+		err := writeJson(filePath, ConvertProofElementsToRawProofElements(secretData))
 		if err != nil {
 			panic(err)
 		}
@@ -24,7 +25,7 @@ func writeTestDataToFile(batchCount int, countPerBatch int) {
 	if lastAccount == nil {
 		panic("lastAccount is nil")
 	}
-	err := writeJson("out/user/test_account.json", lastAccount)
+	err := writeJson("out/user/test_account.json", circuit.ConvertGoAccountToRawGoAccount(*lastAccount))
 	if err != nil {
 		panic(err)
 	}

--- a/core/integration_test.go
+++ b/core/integration_test.go
@@ -45,7 +45,7 @@ func TestVerifyRandomAccount(t *testing.T) {
 	}()
 
 	randomAccount := circuit.GoAccount{
-		UserId:  []byte("random_user_id"),
+		UserId:  []byte("random-user-id"),
 		Balance: circuit.ConstructGoBalance(big.NewInt(123456), big.NewInt(654321)),
 	}
 
@@ -125,7 +125,7 @@ func findProofPathForAccount(account circuit.GoAccount) (bottomProofIdx, midProo
 // TestVerifyProofPathRandomAccount tests that random accounts cannot be verified with any proof path
 func TestVerifyProofPathRandomAccount(t *testing.T) {
 	randomAccount := circuit.GoAccount{
-		UserId:  []byte("random_user_id"),
+		UserId:  []byte("random-user-id"),
 		Balance: circuit.ConstructGoBalance(big.NewInt(123456), big.NewInt(654321)),
 	}
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -50,6 +50,15 @@ type ProofElements struct {
 	MerkleRootWithAssetSumHash []byte
 }
 
+// RawProofElements is contains all the same items as ProofElements, except the accounts are RawGoAccounts
+// should be used when writing to a json file or reading directly from a json file
+type RawProofElements struct {
+	Accounts                   []circuit.RawGoAccount
+	AssetSum                   *circuit.GoBalance
+	MerkleRoot                 []byte
+	MerkleRootWithAssetSumHash []byte
+}
+
 type AccountLeaf = []byte
 
 // CompletedProof is an output of the prover. It contains the proof and public data. It can be published.
@@ -61,6 +70,24 @@ type CompletedProof struct {
 	MerkleRootWithAssetSumHash []byte
 	// AssetSum is optional.
 	AssetSum *circuit.GoBalance
+}
+
+func ConvertProofElementsToRawProofElements(p ProofElements) RawProofElements {
+	return RawProofElements{
+		Accounts:                   circuit.ConvertGoAccountsToRawGoAccounts(p.Accounts),
+		AssetSum:                   p.AssetSum,
+		MerkleRoot:                 p.MerkleRoot,
+		MerkleRootWithAssetSumHash: p.MerkleRootWithAssetSumHash,
+	}
+}
+
+func ConvertRawProofElementsToProofElements(rp RawProofElements) ProofElements {
+	return ProofElements{
+		Accounts:                   circuit.ConvertRawGoAccountsToGoAccounts(rp.Accounts),
+		AssetSum:                   rp.AssetSum,
+		MerkleRoot:                 rp.MerkleRoot,
+		MerkleRootWithAssetSumHash: rp.MerkleRootWithAssetSumHash,
+	}
 }
 
 func ReadDataFromFile[D ProofElements | CompletedProof | circuit.GoAccount](filePath string) D {

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"bytes"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"bitgo.com/proof_of_reserves/circuit"
@@ -43,4 +45,249 @@ func TestBatchProofs(t *testing.T) {
 	assert.Equal(2, len(batchProofs(proofs4, 16)))
 	assert.Equal(1000, len(batchProofs(proofs5, 16)))
 	assert.Panics(func() { batchProofs(proofs3, 0) })
+}
+
+func createTestProofElements() ProofElements {
+	// Create sample accounts
+	accounts := []circuit.GoAccount{
+		{
+			UserId: []byte{1, 2, 3},
+			Balance: circuit.ConstructGoBalance(big.NewInt(100), big.NewInt(200)),
+		},
+		{
+			UserId: []byte{4, 5, 6},
+			Balance: circuit.ConstructGoBalance(big.NewInt(300), big.NewInt(400)),
+		},
+	}
+
+	// Sum balances for test data
+	assetSum := circuit.SumGoAccountBalances(accounts)
+
+	// Create merkle root and hash
+	merkleRoot := []byte{10, 11, 12, 13}
+	merkleRootWithAssetSumHash := []byte{20, 21, 22, 23}
+
+	return ProofElements{
+		Accounts:                   accounts,
+		AssetSum:                   &assetSum,
+		MerkleRoot:                 merkleRoot,
+		MerkleRootWithAssetSumHash: merkleRootWithAssetSumHash,
+	}
+}
+
+func createTestRawProofElements() RawProofElements {
+	// Create sample accounts
+	accounts := []circuit.RawGoAccount{
+		{
+			UserId: "user1",
+			Balance: circuit.ConstructGoBalance(big.NewInt(100), big.NewInt(200)),
+		},
+		{
+			UserId: "user2",
+			Balance: circuit.ConstructGoBalance(big.NewInt(300), big.NewInt(400)),
+		},
+	}
+
+	// Sum balances for test data
+	converted := circuit.ConvertRawGoAccountsToGoAccounts(accounts)
+	assetSum := circuit.SumGoAccountBalances(converted)
+
+	// Create merkle root and hash
+	merkleRoot := []byte{10, 11, 12, 13}
+	merkleRootWithAssetSumHash := []byte{20, 21, 22, 23}
+
+	return RawProofElements{
+		Accounts:                   accounts,
+		AssetSum:                   &assetSum,
+		MerkleRoot:                 merkleRoot,
+		MerkleRootWithAssetSumHash: merkleRootWithAssetSumHash,
+	}
+}
+
+func TestConvertProofElementsToRawProofElements(t *testing.T) {
+	// Create test ProofElements
+	original := createTestProofElements()
+
+	// Convert to RawProofElements
+	result := ConvertProofElementsToRawProofElements(original)
+
+	// Verify accounts have been correctly converted
+	if len(result.Accounts) != len(original.Accounts) {
+		t.Errorf("Expected %d accounts, got %d", len(original.Accounts), len(result.Accounts))
+	}
+
+	// Verify account conversion by checking a sample
+	// Convert back to bytes for comparison
+	convertedUserId := circuit.ConvertRawGoAccountToGoAccount(result.Accounts[0]).UserId
+	if !bytes.Equal(convertedUserId, original.Accounts[0].UserId) {
+		t.Errorf("UserId not converted correctly. Expected %v, got %v after reconversion",
+			original.Accounts[0].UserId, convertedUserId)
+	}
+
+	// Verify AssetSum is preserved (same pointer)
+	if result.AssetSum != original.AssetSum {
+		t.Errorf("AssetSum pointer not preserved")
+	}
+
+	// Verify MerkleRoot is preserved
+	if !bytes.Equal(result.MerkleRoot, original.MerkleRoot) {
+		t.Errorf("MerkleRoot not preserved")
+	}
+
+	// Verify MerkleRootWithAssetSumHash is preserved
+	if !bytes.Equal(result.MerkleRootWithAssetSumHash, original.MerkleRootWithAssetSumHash) {
+		t.Errorf("MerkleRootWithAssetSumHash not preserved")
+	}
+}
+
+func TestConvertRawProofElementsToProofElements(t *testing.T) {
+	// Create test RawProofElements
+	original := createTestRawProofElements()
+
+	// Convert to ProofElements
+	result := ConvertRawProofElementsToProofElements(original)
+
+	// Verify accounts have been correctly converted
+	if len(result.Accounts) != len(original.Accounts) {
+		t.Errorf("Expected %d accounts, got %d", len(original.Accounts), len(result.Accounts))
+	}
+
+	// Verify account conversion by checking a sample
+	// Original raw account
+	rawAccount := original.Accounts[0]
+
+	// Converted account
+	convertedAccount := result.Accounts[0]
+
+	// Manually convert raw account to verify
+	expectedAccount := circuit.ConvertRawGoAccountToGoAccount(rawAccount)
+
+	// Compare converted UserIds
+	if !bytes.Equal(convertedAccount.UserId, expectedAccount.UserId) {
+		t.Errorf("UserId not converted correctly")
+	}
+
+	// Compare balances
+	if !convertedAccount.Balance.Equals(expectedAccount.Balance) {
+		t.Errorf("Balance not converted correctly")
+	}
+
+	// Verify AssetSum is preserved (same pointer)
+	if result.AssetSum != original.AssetSum {
+		t.Errorf("AssetSum pointer not preserved")
+	}
+
+	// Verify MerkleRoot is preserved
+	if !bytes.Equal(result.MerkleRoot, original.MerkleRoot) {
+		t.Errorf("MerkleRoot not preserved")
+	}
+
+	// Verify MerkleRootWithAssetSumHash is preserved
+	if !bytes.Equal(result.MerkleRootWithAssetSumHash, original.MerkleRootWithAssetSumHash) {
+		t.Errorf("MerkleRootWithAssetSumHash not preserved")
+	}
+}
+
+func TestRoundTripProofElementsToRaw(t *testing.T) {
+	// Create test ProofElements
+	original := createTestProofElements()
+
+	// Convert to RawProofElements and back
+	raw := ConvertProofElementsToRawProofElements(original)
+	result := ConvertRawProofElementsToProofElements(raw)
+
+	// Verify accounts have been correctly round-tripped
+	if len(result.Accounts) != len(original.Accounts) {
+		t.Errorf("Expected %d accounts, got %d", len(original.Accounts), len(result.Accounts))
+	}
+
+	// Verify account conversion for each account
+	for i, originalAccount := range original.Accounts {
+		resultAccount := result.Accounts[i]
+
+		// UserId may be different due to base36 conversion and back, but should be functionally equivalent
+		// Original UserId -> RawUserId (base36) -> UserId could produce different byte representation
+		// but with equivalent numerical value
+
+		// Instead, test with account hashing which is what matters functionally
+		originalHash := circuit.GoComputeMiMCHashForAccount(originalAccount)
+		resultHash := circuit.GoComputeMiMCHashForAccount(resultAccount)
+
+		if !bytes.Equal(originalHash, resultHash) {
+			t.Errorf("Account #%d hash doesn't match after round-trip", i)
+		}
+
+		// Balances should remain the same
+		if !resultAccount.Balance.Equals(originalAccount.Balance) {
+			t.Errorf("Account #%d balance doesn't match after round-trip", i)
+		}
+	}
+
+	// Verify AssetSum is preserved
+	if !reflect.DeepEqual(result.AssetSum, original.AssetSum) {
+		t.Errorf("AssetSum not preserved in round-trip")
+	}
+
+	// Verify MerkleRoot is preserved
+	if !bytes.Equal(result.MerkleRoot, original.MerkleRoot) {
+		t.Errorf("MerkleRoot not preserved in round-trip")
+	}
+
+	// Verify MerkleRootWithAssetSumHash is preserved
+	if !bytes.Equal(result.MerkleRootWithAssetSumHash, original.MerkleRootWithAssetSumHash) {
+		t.Errorf("MerkleRootWithAssetSumHash not preserved in round-trip")
+	}
+}
+
+func TestRoundTripRawToProofElements(t *testing.T) {
+	// Create test RawProofElements
+	original := createTestRawProofElements()
+
+	// Convert to ProofElements and back
+	proof := ConvertRawProofElementsToProofElements(original)
+	result := ConvertProofElementsToRawProofElements(proof)
+
+	// Verify accounts have been correctly round-tripped
+	if len(result.Accounts) != len(original.Accounts) {
+		t.Errorf("Expected %d accounts, got %d", len(original.Accounts), len(result.Accounts))
+	}
+
+	// Verify UserIds - these may have changed format but should be functionally equivalent
+	// Check that each userId in the result can be converted to a byte representation that
+	// when hashed produces the same hash as the original userId
+	for i, originalAccount := range original.Accounts {
+		resultAccount := result.Accounts[i]
+
+		// Convert both to GoAccounts for comparison
+		originalGo := circuit.ConvertRawGoAccountToGoAccount(originalAccount)
+		resultGo := circuit.ConvertRawGoAccountToGoAccount(resultAccount)
+
+		// Check account hashing
+		originalHash := circuit.GoComputeMiMCHashForAccount(originalGo)
+		resultHash := circuit.GoComputeMiMCHashForAccount(resultGo)
+
+		if !bytes.Equal(originalHash, resultHash) {
+			t.Errorf("Account #%d hash doesn't match after round-trip", i)
+		}
+
+		// Balances should remain the same
+		if !resultAccount.Balance.Equals(originalAccount.Balance) {
+			t.Errorf("Account #%d balance doesn't match after round-trip", i)
+		}
+	}
+
+	// Verify AssetSum is preserved
+	if !reflect.DeepEqual(result.AssetSum, original.AssetSum) {
+		t.Errorf("AssetSum not preserved in round-trip")
+	}
+
+	// Verify MerkleRoot is preserved
+	if !bytes.Equal(result.MerkleRoot, original.MerkleRoot) {
+		t.Errorf("MerkleRoot not preserved in round-trip")
+	}
+
+	// Verify MerkleRootWithAssetSumHash is preserved
+	if !bytes.Equal(result.MerkleRootWithAssetSumHash, original.MerkleRootWithAssetSumHash) {
+		t.Errorf("MerkleRootWithAssetSumHash not preserved in round-trip")
+	}
 }


### PR DESCRIPTION
Originally userId's were directly being read as bytes from json files, which would cause overflow errors in the circuit for the typical length userIds for accounts retrieved from snowflake. To solve this issue:
- a new account type, called RawGoAccount, was added
- changed logic so when accounts are read from a json file, they are read into the RawGoAccount struct and when they are written to json, they are written in the form of a RawGoAccount
- a RawGoAccount is converted to a GoAccount (before doing anything with it) by reading the rawAccount.userId as a base36 string and _then_ converting it to bytes - as long as the userId is less than 49 characters in length, it will not overflow the BN254 curve limit - the opposite happens when a GoAccount is converted to a RawGoAccount
- a new proof element type, called RawProofElements, was added and is used to read proof element data from json and write data to json