### PR TITLE
Read User Account Balances as Strings

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -150,9 +150,22 @@ func ReadDataFromFile[D ProofElements | CompletedProof | circuit.GoAccount | Use
 			actualTopProofAssetSum = &convertedAssetSum
 		}
 
+		// convert user account balance from []string to circuit.GoBalance
+		convertedBalance := make(circuit.GoBalance, len(rawUserElements.AccountInfo.Balance))
+		for i, asset := range rawUserElements.AccountInfo.Balance {
+			bigIntValue, ok := new(big.Int).SetString(asset, 10)
+			if !ok {
+				panic("Error converting account balance string to big.Int: " + asset)
+			}
+			convertedBalance[i] = bigIntValue
+		}
+
 		// construct the UserVerificationElements from the raw data
 		actualUserElements := UserVerificationElements{
-			AccountInfo: circuit.ConvertRawGoAccountToGoAccount(rawUserElements.AccountInfo),
+			AccountInfo: circuit.ConvertRawGoAccountToGoAccount(circuit.RawGoAccount{
+				UserId:  rawUserElements.AccountInfo.UserId,
+				Balance: convertedBalance,
+			}),
 			ProofInfo: UserProofInfo{
 				UserMerklePath:     rawUserElements.ProofInfo.UserMerklePath,
 				UserMerklePosition: rawUserElements.ProofInfo.UserMerklePosition,

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -491,9 +491,9 @@ func TestReadDataFromFile(t *testing.T) {
 
 		// Create raw user verification elements
 		rawUserElements := RawUserVerificationElements{
-			AccountInfo: circuit.RawGoAccount{
+			AccountInfo: RawUserAccountInfo{
 				UserId:  "test-user-abc",
-				Balance: circuit.ConstructGoBalance(big.NewInt(500), big.NewInt(700)),
+				Balance: []string{"500", "700"},
 			},
 			ProofInfo: RawUserProofInfo{
 				UserMerklePath:     []Hash{{1, 2, 3}, {4, 5, 6}},
@@ -534,7 +534,10 @@ func TestReadDataFromFile(t *testing.T) {
 		result := ReadDataFromFile[UserVerificationElements](filePath)
 
 		// Verify AccountInfo
-		expectedAccount := circuit.ConvertRawGoAccountToGoAccount(rawUserElements.AccountInfo)
+		expectedAccount := circuit.ConvertRawGoAccountToGoAccount(circuit.RawGoAccount{
+			UserId:  rawUserElements.AccountInfo.UserId,
+			Balance: circuit.ConstructGoBalance(big.NewInt(500), big.NewInt(700)),
+		})
 		if !bytes.Equal(result.AccountInfo.UserId, expectedAccount.UserId) {
 			t.Errorf("UserId not converted correctly: expected %v, got %v",
 				expectedAccount.UserId, result.AccountInfo.UserId)

--- a/core/verifier.go
+++ b/core/verifier.go
@@ -27,8 +27,13 @@ type UserVerificationElements struct {
 }
 
 type RawUserVerificationElements struct {
-	AccountInfo circuit.RawGoAccount
+	AccountInfo RawUserAccountInfo
 	ProofInfo   RawUserProofInfo
+}
+
+type RawUserAccountInfo struct {
+	UserId  string
+	Balance []string
 }
 
 type RawUserProofInfo struct {


### PR DESCRIPTION
Updated `UserVerificationElement` parsing logic to read the `AccountInfo.Balance` field as a string from JSON, before converting it to the appropriate type - this is necessary since `UserVerificationElement` will be constructed in a TypeScript service and in TypeScript, large (greater than 64 bit) integers must be written as a string while writing to JSON.