### PR TITLE
feat: read new format balances properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then run the binary using
 
 This is the command used by a client with a Go Account to verify their account balance was included in the total liabilities published by BitGo. Steps for verification for a Go Account:
 1) Login to the BitGo website.
-2) Navigate to the Assets > GoAccount tab and click on the "Download Liability Proofs" button to download the `accountproof.json` corresponding to the Go Account. (At this point, it can be verified that inside `AccountInfo` object inside the downloaded file, the `UserId` field corresponds to the wallet address of the Go Account and the Balance list corresponds to the balance of the GoAccount for supported currencies.)
+2) Navigate to the Assets > GoAccount tab and click on the "Download Liability Proofs" button to download the `accountproof.json` corresponding to the Go Account. (At this point, it can be verified that inside `AccountInfo` object inside the downloaded file, the `WalletId` field corresponds to the wallet address of the Go Account and the Balance list corresponds to the balance of the GoAccount for supported currencies.)
 3) Using the binary, run:
 ```bash
 ./bgproof userverify path/to/accountproof.json
@@ -75,7 +75,7 @@ This system uses a multi-layer Merkle Tree architecture combined with zk-SNARK c
 
 ### Key Concepts
 
-- **GoAccount**: Consists of a UserId (walletId) and a Balance list for the wallet.
+- **GoAccount**: Consists of a WalletId (walletId) and a Balance list for the wallet.
 - **GoBalance**: Each element of the Balance list corresponds to the amount of a particular currency the account holds. The currency an element at a particular index correponds to is the currency that is given at that index in the `AssetSymbols` list located in `circuit/constants.go`. This type is also the same type used to represent asset sums at any layer in the merkle tree.
 
 ### 3-Layer Proof Construction

--- a/circuit/circuit.go
+++ b/circuit/circuit.go
@@ -57,7 +57,7 @@ func hashBalance(hasher mimc.MiMC, balances Balance) (hash frontend.Variable) {
 // hashAccount computes the MiMC hash of the account. GoComputeMiMCHashForAccount is the Go equivalent for general use.
 func hashAccount(hasher mimc.MiMC, account Account) (hash frontend.Variable) {
 	hasher.Reset()
-	hasher.Write(account.UserId, hashBalance(hasher, account.Balance))
+	hasher.Write(account.WalletId, hashBalance(hasher, account.Balance))
 	return hasher.Sum()
 }
 
@@ -143,7 +143,7 @@ func (circuit *Circuit) Define(api frontend.API) error {
 	assertBalancesAreEqual(api, runningBalance, circuit.AssetSum)
 	root := computeMerkleRootFromAccounts(hasher, circuit.Accounts)
 	api.AssertIsEqual(root, circuit.MerkleRoot)
-	rootWithSum := hashAccount(hasher, Account{UserId: circuit.MerkleRoot, Balance: circuit.AssetSum})
+	rootWithSum := hashAccount(hasher, Account{WalletId: circuit.MerkleRoot, Balance: circuit.AssetSum})
 	api.AssertIsEqual(rootWithSum, circuit.MerkleRootWithAssetSumHash)
 
 	return nil

--- a/circuit/circuit_test.go
+++ b/circuit/circuit_test.go
@@ -63,7 +63,7 @@ func TestCircuitDoesNotAcceptAccountsWithOverflow(t *testing.T) {
 
 	// create account with overflow balance, based on first generated go account
 	badBalanceAccount := GoAccount{
-		UserId:  GO_ACCOUNTS[0].UserId,
+		WalletId:  GO_ACCOUNTS[0].WalletId,
 		Balance: append(GO_ACCOUNTS[0].Balance[1:], new(big.Int).SetBytes(overflowBalance)),
 	}
 

--- a/circuit/types.go
+++ b/circuit/types.go
@@ -11,7 +11,7 @@ type Balance []frontend.Variable
 
 // Account is an input to the circuit and is only used in this package. GoAccount is preferred elsewhere.
 type Account struct {
-	UserId  frontend.Variable
+	WalletId  frontend.Variable
 	Balance Balance
 }
 
@@ -33,13 +33,13 @@ type GoBalance []*big.Int
 // GoAccount represents an account. It can be converted to Account for use in the circuit
 // through ConvertGoAccountToAccount.
 type GoAccount struct {
-	UserId  []byte
+	WalletId  []byte
 	Balance GoBalance
 }
 
-// RawGoAccount represents an account read from file (with a string UserId). It can be converted to
+// RawGoAccount represents an account read from file (with a string WalletId). It can be converted to
 // GoAccount (to manipulate here) through ConvertRawGoAccountToAccount.
 type RawGoAccount struct {
-	UserId  string
+	WalletId  string
 	Balance GoBalance
 }

--- a/circuit/utils_test.go
+++ b/circuit/utils_test.go
@@ -63,8 +63,8 @@ func TestPadToModBytes(t *testing.T) {
 func TestGoComputeMiMCHashesForAccounts(t *testing.T) {
 	assert := test.NewAssert(t)
 	accounts := []GoAccount{
-		{UserId: []byte{1, 2}, Balance: ConstructGoBalance(big.NewInt(1000000000), big.NewInt(11111))},
-		{UserId: []byte{1, 3}, Balance: ConstructGoBalance(big.NewInt(0), big.NewInt(22222))},
+		{WalletId: []byte{1, 2}, Balance: ConstructGoBalance(big.NewInt(1000000000), big.NewInt(11111))},
+		{WalletId: []byte{1, 3}, Balance: ConstructGoBalance(big.NewInt(0), big.NewInt(22222))},
 	}
 
 	expectedHashes := []Hash{
@@ -198,7 +198,7 @@ func TestPublicComputeMerkleRootMaxAccountsConstraint(t *testing.T) {
 	accounts := make([]GoAccount, ACCOUNTS_PER_BATCH+1)
 	for i := range accounts {
 		accounts[i] = GoAccount{
-			UserId:  []byte{byte(i % 256)},
+			WalletId:  []byte{byte(i % 256)},
 			Balance: ConstructGoBalance(big.NewInt(1), big.NewInt(1)),
 		}
 	}
@@ -434,11 +434,11 @@ func TestSumGoAccountBalances(t *testing.T) {
 			name: "All positive balances",
 			accounts: []GoAccount{
 				{
-					UserId:  []byte("user1"),
+					WalletId:  []byte("user1"),
 					Balance: ConstructGoBalance(big.NewInt(100), big.NewInt(200)),
 				},
 				{
-					UserId:  []byte("user2"),
+					WalletId:  []byte("user2"),
 					Balance: ConstructGoBalance(big.NewInt(150), big.NewInt(250)),
 				},
 			},
@@ -449,7 +449,7 @@ func TestSumGoAccountBalances(t *testing.T) {
 			name: "With negative balance for first asset",
 			accounts: []GoAccount{
 				{
-					UserId:  []byte("user1"),
+					WalletId:  []byte("user1"),
 					Balance: ConstructGoBalance(big.NewInt(-250), big.NewInt(450)),
 				},
 			},
@@ -460,7 +460,7 @@ func TestSumGoAccountBalances(t *testing.T) {
 			name: "With negative balance for second asset",
 			accounts: []GoAccount{
 				{
-					UserId:  []byte("user1"),
+					WalletId:  []byte("user1"),
 					Balance: ConstructGoBalance(big.NewInt(250), big.NewInt(-450)),
 				},
 			},
@@ -471,7 +471,7 @@ func TestSumGoAccountBalances(t *testing.T) {
 			name: "Zero balances",
 			accounts: []GoAccount{
 				{
-					UserId:  []byte("user1"),
+					WalletId:  []byte("user1"),
 					Balance: ConstructGoBalance(),
 				},
 			},
@@ -573,24 +573,24 @@ func TestGoBalanceEquals(t *testing.T) {
 	}
 }
 
-func TestConvertRawUserIdToBytes(t *testing.T) {
+func TestConvertRawWalletIdToBytes(t *testing.T) {
 	t.Run("basic alphanumeric conversion", func(t *testing.T) {
-		userId := "user123"
-		result := convertRawUserIdToBytes(userId)
+		walletId := "user123"
+		result := convertRawWalletIdToBytes(walletId)
 
 		// Convert back to string to verify
 		n := new(big.Int).SetBytes(result)
 		resultBase36 := n.Text(36)
 
-		if resultBase36 != userId {
-			t.Errorf("Expected %s, got %s", userId, resultBase36)
+		if resultBase36 != walletId {
+			t.Errorf("Expected %s, got %s", walletId, resultBase36)
 		}
 	})
 
-	t.Run("hyphenated userId", func(t *testing.T) {
-		userId := "user-123-456"
+	t.Run("hyphenated walletId", func(t *testing.T) {
+		walletId := "user-123-456"
 		expectedCleanId := "user123456" // hyphens removed
-		result := convertRawUserIdToBytes(userId)
+		result := convertRawWalletIdToBytes(walletId)
 
 		// Convert back to string to verify
 		n := new(big.Int).SetBytes(result)
@@ -602,29 +602,29 @@ func TestConvertRawUserIdToBytes(t *testing.T) {
 	})
 
 	t.Run("invalid characters", func(t *testing.T) {
-		userId := "user@123"
+		walletId := "user@123"
 		defer func() {
 			if r := recover(); r == nil {
 				t.Errorf("Expected panic with invalid characters")
 			}
 		}()
-		convertRawUserIdToBytes(userId)
+		convertRawWalletIdToBytes(walletId)
 	})
 }
 
 func TestConvertRawGoAccountToGoAccount(t *testing.T) {
-	t.Run("standard conversion with alphanumeric and hyphenated userId", func(t *testing.T) {
+	t.Run("standard conversion with alphanumeric and hyphenated walletId", func(t *testing.T) {
 		rawAccount := RawGoAccount{
-			UserId:  "user-123-abc",
+			WalletId:  "user-123-abc",
 			Balance: ConstructGoBalance(big.NewInt(1000), big.NewInt(2000)),
 		}
 
 		result := ConvertRawGoAccountToGoAccount(rawAccount)
 
-		// Verify userId is converted correctly
-		expectedUserId := convertRawUserIdToBytes("user-123-abc")
-		if !bytes.Equal(expectedUserId, result.UserId) {
-			t.Errorf("UserId not converted correctly")
+		// Verify walletId is converted correctly
+		expectedWalletId := convertRawWalletIdToBytes("user-123-abc")
+		if !bytes.Equal(expectedWalletId, result.WalletId) {
+			t.Errorf("WalletId not converted correctly")
 		}
 
 		// Verify balance remains unchanged
@@ -637,18 +637,18 @@ func TestConvertRawGoAccountToGoAccount(t *testing.T) {
 func TestConvertGoAccountToRawGoAccount(t *testing.T) {
 	t.Run("standard conversion", func(t *testing.T) {
 		// Create a GoAccount
-		userId := convertRawUserIdToBytes("user123")
+		walletId := convertRawWalletIdToBytes("user123")
 		goAccount := GoAccount{
-			UserId:  userId,
+			WalletId:  walletId,
 			Balance: ConstructGoBalance(big.NewInt(1000), big.NewInt(2000)),
 		}
 
 		// Convert to RawGoAccount
 		result := ConvertGoAccountToRawGoAccount(goAccount)
 
-		// Verify userId is in base36 format
-		if result.UserId != "user123" {
-			t.Errorf("Expected userId user123, got %s", result.UserId)
+		// Verify walletId is in base36 format
+		if result.WalletId != "user123" {
+			t.Errorf("Expected walletId user123, got %s", result.WalletId)
 		}
 
 		// Verify balance remains unchanged
@@ -659,9 +659,9 @@ func TestConvertGoAccountToRawGoAccount(t *testing.T) {
 
 	t.Run("round trip conversion", func(t *testing.T) {
 		// Start with a GoAccount
-		originalUserId := convertRawUserIdToBytes("test456abc")
+		originalWalletId := convertRawWalletIdToBytes("test456abc")
 		originalAccount := GoAccount{
-			UserId:  originalUserId,
+			WalletId:  originalWalletId,
 			Balance: ConstructGoBalance(big.NewInt(500), big.NewInt(600)),
 		}
 
@@ -670,8 +670,8 @@ func TestConvertGoAccountToRawGoAccount(t *testing.T) {
 		reconvertedAccount := ConvertRawGoAccountToGoAccount(rawAccount)
 
 		// Verify the round trip preserves the data
-		if !bytes.Equal(originalAccount.UserId, reconvertedAccount.UserId) {
-			t.Errorf("UserId should be preserved in round trip")
+		if !bytes.Equal(originalAccount.WalletId, reconvertedAccount.WalletId) {
+			t.Errorf("WalletId should be preserved in round trip")
 		}
 		if !originalAccount.Balance.Equals(reconvertedAccount.Balance) {
 			t.Errorf("Balance should be preserved in round trip")
@@ -684,11 +684,11 @@ func TestBatchConversionFunctions(t *testing.T) {
 		// Create a batch of raw accounts
 		rawAccounts := []RawGoAccount{
 			{
-				UserId:  "user1",
+				WalletId:  "user1",
 				Balance: ConstructGoBalance(big.NewInt(100), big.NewInt(200)),
 			},
 			{
-				UserId:  "user-2",
+				WalletId:  "user-2",
 				Balance: ConstructGoBalance(big.NewInt(300), big.NewInt(400)),
 			},
 		}
@@ -702,18 +702,18 @@ func TestBatchConversionFunctions(t *testing.T) {
 		}
 
 		// Check first account
-		expectedUserId1 := convertRawUserIdToBytes("user1")
-		if !bytes.Equal(expectedUserId1, result[0].UserId) {
-			t.Errorf("First account UserId not converted correctly")
+		expectedWalletId1 := convertRawWalletIdToBytes("user1")
+		if !bytes.Equal(expectedWalletId1, result[0].WalletId) {
+			t.Errorf("First account WalletId not converted correctly")
 		}
 		if !result[0].Balance.Equals(rawAccounts[0].Balance) {
 			t.Errorf("First account Balance should remain unchanged")
 		}
 
 		// Check second account
-		expectedUserId2 := convertRawUserIdToBytes("user-2")
-		if !bytes.Equal(expectedUserId2, result[1].UserId) {
-			t.Errorf("Second account UserId not converted correctly")
+		expectedWalletId2 := convertRawWalletIdToBytes("user-2")
+		if !bytes.Equal(expectedWalletId2, result[1].WalletId) {
+			t.Errorf("Second account WalletId not converted correctly")
 		}
 		if !result[1].Balance.Equals(rawAccounts[1].Balance) {
 			t.Errorf("Second account Balance should remain unchanged")
@@ -724,11 +724,11 @@ func TestBatchConversionFunctions(t *testing.T) {
 		// Create a batch of go accounts
 		accounts := []GoAccount{
 			{
-				UserId:  convertRawUserIdToBytes("user1"),
+				WalletId:  convertRawWalletIdToBytes("user1"),
 				Balance: ConstructGoBalance(big.NewInt(100), big.NewInt(200)),
 			},
 			{
-				UserId:  convertRawUserIdToBytes("user2"),
+				WalletId:  convertRawWalletIdToBytes("user2"),
 				Balance: ConstructGoBalance(big.NewInt(300), big.NewInt(400)),
 			},
 		}
@@ -742,16 +742,16 @@ func TestBatchConversionFunctions(t *testing.T) {
 		}
 
 		// Check first account
-		if result[0].UserId != "user1" {
-			t.Errorf("Expected user1, got %s", result[0].UserId)
+		if result[0].WalletId != "user1" {
+			t.Errorf("Expected user1, got %s", result[0].WalletId)
 		}
 		if !result[0].Balance.Equals(accounts[0].Balance) {
 			t.Errorf("First account Balance should remain unchanged")
 		}
 
 		// Check second account
-		if result[1].UserId != "user2" {
-			t.Errorf("Expected user2, got %s", result[1].UserId)
+		if result[1].WalletId != "user2" {
+			t.Errorf("Expected user2, got %s", result[1].WalletId)
 		}
 		if !result[1].Balance.Equals(accounts[1].Balance) {
 			t.Errorf("Second account Balance should remain unchanged")

--- a/core/prover.go
+++ b/core/prover.go
@@ -31,7 +31,7 @@ func generateProof(elements ProofElements) CompletedProof {
 		elements.MerkleRoot = circuit.GoComputeMerkleRootFromAccounts(elements.Accounts)
 	}
 	if elements.MerkleRootWithAssetSumHash == nil {
-		elements.MerkleRootWithAssetSumHash = circuit.GoComputeMiMCHashForAccount(circuit.GoAccount{UserId: elements.MerkleRoot, Balance: *elements.AssetSum})
+		elements.MerkleRootWithAssetSumHash = circuit.GoComputeMiMCHashForAccount(circuit.GoAccount{WalletId: elements.MerkleRoot, Balance: *elements.AssetSum})
 	}
 
 	// check if compiled proof cached already for this length of accounts
@@ -131,7 +131,7 @@ func writeProofsToFiles(proofs []CompletedProof, prefix string, saveAssetSum boo
 }
 
 // generateNextLevelProofs generates the next level proofs by calling generateProof and treating the lower level
-// proofs as accounts, with MerkleRoot as UserId and AssetSum as Balance.
+// proofs as accounts, with MerkleRoot as WalletId and AssetSum as Balance.
 func generateNextLevelProofs(currentLevelProof []CompletedProof) CompletedProof {
 
 	// properly make accounts for next level proof using currentLevelProofs
@@ -141,7 +141,7 @@ func generateNextLevelProofs(currentLevelProof []CompletedProof) CompletedProof 
 			panic("AssetSum is nil")
 		}
 		// convert lower level proof to GoAccount struct
-		nextLevelProofAccounts[i] = circuit.GoAccount{UserId: currentLevelProof[i].MerkleRoot, Balance: *currentLevelProof[i].AssetSum}
+		nextLevelProofAccounts[i] = circuit.GoAccount{WalletId: currentLevelProof[i].MerkleRoot, Balance: *currentLevelProof[i].AssetSum}
 		if !bytes.Equal(currentLevelProof[i].MerkleRootWithAssetSumHash, circuit.GoComputeMiMCHashForAccount(nextLevelProofAccounts[i])) {
 			panic("Merkle root with asset sum hash does not match")
 		}
@@ -154,7 +154,7 @@ func generateNextLevelProofs(currentLevelProof []CompletedProof) CompletedProof 
 		Accounts:                   nextLevelProofAccounts,
 		MerkleRoot:                 merkleRoot,
 		AssetSum:                   &assetSum,
-		MerkleRootWithAssetSumHash: circuit.GoComputeMiMCHashForAccount(circuit.GoAccount{UserId: merkleRoot, Balance: assetSum}),
+		MerkleRootWithAssetSumHash: circuit.GoComputeMiMCHashForAccount(circuit.GoAccount{WalletId: merkleRoot, Balance: assetSum}),
 	})
 }
 

--- a/core/types.go
+++ b/core/types.go
@@ -79,6 +79,11 @@ type UserVerificationElements struct {
 }
 
 // Types for reading and writing raw user verification elements from/to files:
+type RawUVBalance struct {
+	Asset  string
+	Amount string
+}
+
 type RawLowerLevelProof struct {
 	Proof                      string
 	VerificationKey            string
@@ -93,7 +98,7 @@ type RawTopLevelProof struct {
 	VerificationKey            string
 	MerkleRoot                 []byte
 	MerkleRootWithAssetSumHash []byte
-	AssetSum                   *[]string
+	AssetSum                   *[]RawUVBalance
 }
 
 type RawUserProofInfo struct {
@@ -106,7 +111,7 @@ type RawUserProofInfo struct {
 
 type RawUserAccountInfo struct {
 	UserId  string
-	Balance []string
+	Balance []RawUVBalance
 }
 
 type RawUserVerificationElements struct {

--- a/core/types.go
+++ b/core/types.go
@@ -110,7 +110,7 @@ type RawUserProofInfo struct {
 }
 
 type RawUserAccountInfo struct {
-	UserId  string
+	WalletId  string
 	Balance []RawUVBalance
 }
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -140,10 +140,10 @@ func ReadDataFromFile[D ProofElements | CompletedProof | circuit.GoAccount | Use
 			panic("reading user verification elements failed: TopProof.AssetSum is nil")
 		} else {
 			convertedAssetSum := make(circuit.GoBalance, len(*rawUserElements.ProofInfo.TopProof.AssetSum))
-			for i, asset := range *rawUserElements.ProofInfo.TopProof.AssetSum {
-				bigIntValue, ok := new(big.Int).SetString(asset, 10)
+			for i, assetBalance := range *rawUserElements.ProofInfo.TopProof.AssetSum {
+				bigIntValue, ok := new(big.Int).SetString(assetBalance.Amount, 10)
 				if !ok {
-					panic("Error converting asset sum string to big.Int: " + asset)
+					panic("Error converting asset sum string to big.Int: " + assetBalance.Amount)
 				}
 				convertedAssetSum[i] = bigIntValue
 			}
@@ -152,10 +152,10 @@ func ReadDataFromFile[D ProofElements | CompletedProof | circuit.GoAccount | Use
 
 		// convert user account balance from []string to circuit.GoBalance
 		convertedBalance := make(circuit.GoBalance, len(rawUserElements.AccountInfo.Balance))
-		for i, asset := range rawUserElements.AccountInfo.Balance {
-			bigIntValue, ok := new(big.Int).SetString(asset, 10)
+		for i, assetBalance := range rawUserElements.AccountInfo.Balance {
+			bigIntValue, ok := new(big.Int).SetString(assetBalance.Amount, 10)
 			if !ok {
-				panic("Error converting account balance string to big.Int: " + asset)
+				panic("Error converting account balance string to big.Int: " + assetBalance.Amount)
 			}
 			convertedBalance[i] = bigIntValue
 		}

--- a/core/utils.go
+++ b/core/utils.go
@@ -14,7 +14,7 @@ func ConvertProofToGoAccount(proof CompletedProof) circuit.GoAccount {
 		panic("AssetSum is nil, cannot convert to GoAccount")
 	}
 	return circuit.GoAccount{
-		UserId:  proof.MerkleRoot,
+		WalletId:  proof.MerkleRoot,
 		Balance: *proof.AssetSum,
 	}
 }
@@ -163,7 +163,7 @@ func ReadDataFromFile[D ProofElements | CompletedProof | circuit.GoAccount | Use
 		// construct the UserVerificationElements from the raw data
 		actualUserElements := UserVerificationElements{
 			AccountInfo: circuit.ConvertRawGoAccountToGoAccount(circuit.RawGoAccount{
-				UserId:  rawUserElements.AccountInfo.UserId,
+				WalletId:  rawUserElements.AccountInfo.WalletId,
 				Balance: convertedBalance,
 			}),
 			ProofInfo: UserProofInfo{

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -492,8 +492,11 @@ func TestReadDataFromFile(t *testing.T) {
 		// Create raw user verification elements
 		rawUserElements := RawUserVerificationElements{
 			AccountInfo: RawUserAccountInfo{
-				WalletId:  "test-user-abc",
-				Balance: []string{"500", "700"},
+				WalletId: "test-user-abc",
+				Balance: []RawUVBalance{
+					{Asset: "BTC", Amount: "500"},
+					{Asset: "ETH", Amount: "700"},
+				},
 			},
 			ProofInfo: RawUserProofInfo{
 				UserMerklePath:     []Hash{{1, 2, 3}, {4, 5, 6}},
@@ -519,7 +522,10 @@ func TestReadDataFromFile(t *testing.T) {
 					VerificationKey:            "TopVK",
 					MerkleRoot:                 []byte{25, 26, 27},
 					MerkleRootWithAssetSumHash: []byte{28, 29, 30},
-					AssetSum:                   &[]string{"1000", "2000"},
+					AssetSum: &[]RawUVBalance{
+						{Asset: "BTC", Amount: "1000"},
+						{Asset: "ETH", Amount: "2000"},
+					},
 				},
 			},
 		}

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -33,11 +33,11 @@ func createTestProofElements() ProofElements {
 	// Create sample accounts
 	accounts := []circuit.GoAccount{
 		{
-			UserId:  []byte{1, 2, 3},
+			WalletId:  []byte{1, 2, 3},
 			Balance: circuit.ConstructGoBalance(big.NewInt(100), big.NewInt(200)),
 		},
 		{
-			UserId:  []byte{4, 5, 6},
+			WalletId:  []byte{4, 5, 6},
 			Balance: circuit.ConstructGoBalance(big.NewInt(300), big.NewInt(400)),
 		},
 	}
@@ -61,11 +61,11 @@ func createTestRawProofElements() RawProofElements {
 	// Create sample accounts
 	accounts := []circuit.RawGoAccount{
 		{
-			UserId:  "user1",
+			WalletId:  "user1",
 			Balance: circuit.ConstructGoBalance(big.NewInt(100), big.NewInt(200)),
 		},
 		{
-			UserId:  "user2",
+			WalletId:  "user2",
 			Balance: circuit.ConstructGoBalance(big.NewInt(300), big.NewInt(400)),
 		},
 	}
@@ -100,10 +100,10 @@ func TestConvertProofElementsToRawProofElements(t *testing.T) {
 
 	// Verify account conversion by checking a sample
 	// Convert back to bytes for comparison
-	convertedUserId := circuit.ConvertRawGoAccountToGoAccount(result.Accounts[0]).UserId
-	if !bytes.Equal(convertedUserId, original.Accounts[0].UserId) {
-		t.Errorf("UserId not converted correctly. Expected %v, got %v after reconversion",
-			original.Accounts[0].UserId, convertedUserId)
+	convertedWalletId := circuit.ConvertRawGoAccountToGoAccount(result.Accounts[0]).WalletId
+	if !bytes.Equal(convertedWalletId, original.Accounts[0].WalletId) {
+		t.Errorf("WalletId not converted correctly. Expected %v, got %v after reconversion",
+			original.Accounts[0].WalletId, convertedWalletId)
 	}
 
 	// Verify AssetSum is preserved (same pointer)
@@ -144,9 +144,9 @@ func TestConvertRawProofElementsToProofElements(t *testing.T) {
 	// Manually convert raw account to verify
 	expectedAccount := circuit.ConvertRawGoAccountToGoAccount(rawAccount)
 
-	// Compare converted UserIds
-	if !bytes.Equal(convertedAccount.UserId, expectedAccount.UserId) {
-		t.Errorf("UserId not converted correctly")
+	// Compare converted WalletIds
+	if !bytes.Equal(convertedAccount.WalletId, expectedAccount.WalletId) {
+		t.Errorf("WalletId not converted correctly")
 	}
 
 	// Compare balances
@@ -187,8 +187,8 @@ func TestRoundTripProofElementsToRaw(t *testing.T) {
 	for i, originalAccount := range original.Accounts {
 		resultAccount := result.Accounts[i]
 
-		// UserId may be different due to base36 conversion and back, but should be functionally equivalent
-		// Original UserId -> RawUserId (base36) -> UserId could produce different byte representation
+		// WalletId may be different due to base36 conversion and back, but should be functionally equivalent
+		// Original WalletId -> RawWalletId (base36) -> WalletId could produce different byte representation
 		// but with equivalent numerical value
 
 		// Instead, test with account hashing which is what matters functionally
@@ -234,9 +234,9 @@ func TestRoundTripRawToProofElements(t *testing.T) {
 		t.Errorf("Expected %d accounts, got %d", len(original.Accounts), len(result.Accounts))
 	}
 
-	// Verify UserIds - these may have changed format but should be functionally equivalent
-	// Check that each userId in the result can be converted to a byte representation that
-	// when hashed produces the same hash as the original userId
+	// Verify WalletIds - these may have changed format but should be functionally equivalent
+	// Check that each walletId in the result can be converted to a byte representation that
+	// when hashed produces the same hash as the original walletId
 	for i, originalAccount := range original.Accounts {
 		resultAccount := result.Accounts[i]
 
@@ -301,10 +301,10 @@ func TestReadDataFromFile(t *testing.T) {
 			t.Errorf("Expected 2 accounts, got %d", len(result.Accounts))
 		}
 
-		// Verify account conversions - check UserId by converting raw accounts
+		// Verify account conversions - check WalletId by converting raw accounts
 		for i := 0; i < 2; i++ {
-			if !bytes.Equal(result.Accounts[i].UserId, circuit.ConvertRawGoAccountToGoAccount(raw.Accounts[i]).UserId) {
-				t.Errorf("UserId for account %d not converted correctly", i)
+			if !bytes.Equal(result.Accounts[i].WalletId, circuit.ConvertRawGoAccountToGoAccount(raw.Accounts[i]).WalletId) {
+				t.Errorf("WalletId for account %d not converted correctly", i)
 			}
 		}
 
@@ -458,7 +458,7 @@ func TestReadDataFromFile(t *testing.T) {
 		filePath := "testutildata/test_account_0.json"
 		// Create RawGoAccount and write to file directly with writeJson
 		rawAccount := circuit.RawGoAccount{
-			UserId:  "test-account-123",
+			WalletId:  "test-account-123",
 			Balance: circuit.ConstructGoBalance(big.NewInt(100), big.NewInt(200)),
 		}
 		err := writeJson(filePath, rawAccount)
@@ -473,10 +473,10 @@ func TestReadDataFromFile(t *testing.T) {
 		// Verify it's properly converted from RawGoAccount
 		expectedAccount := circuit.ConvertRawGoAccountToGoAccount(rawAccount)
 
-		// Verify UserID was properly converted
-		if !bytes.Equal(result.UserId, expectedAccount.UserId) {
-			t.Errorf("UserId not converted correctly: expected %v, got %v",
-				expectedAccount.UserId, result.UserId)
+		// Verify WalletId was properly converted
+		if !bytes.Equal(result.WalletId, expectedAccount.WalletId) {
+			t.Errorf("WalletId not converted correctly: expected %v, got %v",
+				expectedAccount.WalletId, result.WalletId)
 		}
 
 		// Verify balance
@@ -492,7 +492,7 @@ func TestReadDataFromFile(t *testing.T) {
 		// Create raw user verification elements
 		rawUserElements := RawUserVerificationElements{
 			AccountInfo: RawUserAccountInfo{
-				UserId:  "test-user-abc",
+				WalletId:  "test-user-abc",
 				Balance: []string{"500", "700"},
 			},
 			ProofInfo: RawUserProofInfo{
@@ -535,12 +535,12 @@ func TestReadDataFromFile(t *testing.T) {
 
 		// Verify AccountInfo
 		expectedAccount := circuit.ConvertRawGoAccountToGoAccount(circuit.RawGoAccount{
-			UserId:  rawUserElements.AccountInfo.UserId,
+			WalletId:  rawUserElements.AccountInfo.WalletId,
 			Balance: circuit.ConstructGoBalance(big.NewInt(500), big.NewInt(700)),
 		})
-		if !bytes.Equal(result.AccountInfo.UserId, expectedAccount.UserId) {
-			t.Errorf("UserId not converted correctly: expected %v, got %v",
-				expectedAccount.UserId, result.AccountInfo.UserId)
+		if !bytes.Equal(result.AccountInfo.WalletId, expectedAccount.WalletId) {
+			t.Errorf("WalletId not converted correctly: expected %v, got %v",
+				expectedAccount.WalletId, result.AccountInfo.WalletId)
 		}
 		if result.AccountInfo.Balance[0].Cmp(big.NewInt(500)) != 0 ||
 			result.AccountInfo.Balance[1].Cmp(big.NewInt(700)) != 0 {
@@ -713,7 +713,7 @@ func TestWriteReadDataRoundTrip(t *testing.T) {
 	t.Run("Round trip GoAccount", func(t *testing.T) {
 		// Create test data
 		rawAccount := circuit.RawGoAccount{
-			UserId:  "test-account-xyz",
+			WalletId:  "test-account-xyz",
 			Balance: circuit.ConstructGoBalance(big.NewInt(123), big.NewInt(456)),
 		}
 		original := circuit.ConvertRawGoAccountToGoAccount(rawAccount)
@@ -726,7 +726,7 @@ func TestWriteReadDataRoundTrip(t *testing.T) {
 		// Read back from file
 		result := ReadDataFromFile[circuit.GoAccount](filePath)
 
-		// Verify account hash matches (since UserId byte representation might differ due to conversion)
+		// Verify account hash matches (since WalletId byte representation might differ due to conversion)
 		originalHash := circuit.GoComputeMiMCHashForAccount(original)
 		resultHash := circuit.GoComputeMiMCHashForAccount(result)
 		if !bytes.Equal(originalHash, resultHash) {

--- a/core/verifier_test.go
+++ b/core/verifier_test.go
@@ -307,7 +307,7 @@ func TestVerifyUser(t *testing.T) {
 		{
 			"Invalid account data",
 			UserVerificationElements{
-				AccountInfo: circuit.GoAccount{UserId: []byte{0x23}},
+				AccountInfo: circuit.GoAccount{WalletId: []byte{0x23}},
 				ProofInfo: UserProofInfo{
 					UserMerklePath:     accountMerklePath,
 					UserMerklePosition: accountPosition,
@@ -322,7 +322,7 @@ func TestVerifyUser(t *testing.T) {
 			"Invalid balance",
 			UserVerificationElements{
 				AccountInfo: circuit.GoAccount{
-					UserId:  account.UserId,
+					WalletId:  account.WalletId,
 					Balance: append(circuit.GoBalance{new(big.Int).Add(new(big.Int).Set(account.Balance[0]), big.NewInt(2))}, account.Balance[1:]...),
 				},
 				ProofInfo: UserProofInfo{
@@ -610,7 +610,7 @@ func TestVerifyFull(t *testing.T) {
 		invalidAccountIncluded[i] = make([]circuit.GoAccount, len(validAccountBatches[i]))
 		for j := range validAccountBatches[i] {
 			// deep copy each account
-			invalidAccountIncluded[i][j].UserId = append([]byte{}, validAccountBatches[i][j].UserId...)
+			invalidAccountIncluded[i][j].WalletId = append([]byte{}, validAccountBatches[i][j].WalletId...)
 			// deep copy balance slice
 			invalidAccountIncluded[i][j].Balance = make(circuit.GoBalance, len(validAccountBatches[i][j].Balance))
 			for k, bal := range validAccountBatches[i][j].Balance {
@@ -618,14 +618,14 @@ func TestVerifyFull(t *testing.T) {
 			}
 		}
 	}
-	invalidAccountIncluded[1][1].UserId = []byte{0x34, 0x28, 0x29}
+	invalidAccountIncluded[1][1].WalletId = []byte{0x34, 0x28, 0x29}
 
 	invalidBalanceIncluded := make([][]circuit.GoAccount, len(validAccountBatches))
 	for i := range validAccountBatches {
 		invalidBalanceIncluded[i] = make([]circuit.GoAccount, len(validAccountBatches[i]))
 		for j := range validAccountBatches[i] {
 			// deep copy each account
-			invalidBalanceIncluded[i][j].UserId = append([]byte{}, validAccountBatches[i][j].UserId...)
+			invalidBalanceIncluded[i][j].WalletId = append([]byte{}, validAccountBatches[i][j].WalletId...)
 			// deep copy balance slice
 			invalidBalanceIncluded[i][j].Balance = make(circuit.GoBalance, len(validAccountBatches[i][j].Balance))
 			for k, bal := range validAccountBatches[i][j].Balance {


### PR DESCRIPTION
This PR adds support to parse a more readable format of `RawUserVerificationElements` (which better associates asset symbols with the corresponding asset balance). Also, all occurrences of `UserId` have been replaced with `WalletId` (which better represents what the ID actually is).

BTC-2377