### PR TITLE
Fix typos and grammar in comments and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository is part of BitGo's proof of solvency implementation for Go Accounts, enabling clients to verify that their assets are fully backed. The repository contains code for generating liability proofs and verifying them through a multi-level merkle tree structure with zero-knowledge proofs.
 
-[Note: BitGo website UI updates to view total liabilites and download liability proofs for Go Accounts are still underway.]
+[Note: BitGo website UI updates to view total liabilities and download liability proofs for Go Accounts are still underway.]
 
 ## Usage
 
@@ -51,7 +51,7 @@ This generates proofs for accounts in the files `batch_0.json...batch_n.json` in
 
 This command is used for complete verification of generated proofs. It assumes generated proofs are in `out/public` and the accounts batches used as input are in `out/secret`. It verifies:
 1) Each bottom-layer, mid-layer, and top-layer proof in `out/public` can be verified by the circuit.
-2) Each bottom-layer proof was included in an mid-layer proof and each mid-layer proof was included in the top-layer proof.
+2) Each bottom-layer proof was included in a mid-layer proof and each mid-layer proof was included in the top-layer proof.
 3) Each account in `out/secret` was included in a bottom-layer proof.
 4) Each bottom proof has a valid set of merkle nodes (which can be later used to compute merkle paths for accounts).
 This can be useful for checking that the proofs were correctly generated. Please note that filenames are fixed,
@@ -76,7 +76,7 @@ This system uses a multi-layer Merkle Tree architecture combined with zk-SNARK c
 ### Key Concepts
 
 - **GoAccount**: Consists of a WalletId (walletId) and a Balance list for the wallet.
-- **GoBalance**: Each element of the Balance list corresponds to the amount of a particular currency the account holds. The currency an element at a particular index correponds to is the currency that is given at that index in the `AssetSymbols` list located in `circuit/constants.go`. This type is also the same type used to represent asset sums at any layer in the merkle tree.
+- **GoBalance**: Each element of the Balance list corresponds to the amount of a particular currency the account holds. The currency an element at a particular index corresponds to is the currency that is given at that index in the `AssetSymbols` list located in `circuit/constants.go`. This type is also the same type used to represent asset sums at any layer in the merkle tree.
 
 ### 3-Layer Proof Construction
 

--- a/circuit/utils.go
+++ b/circuit/utils.go
@@ -315,7 +315,7 @@ func ConstructGoBalance(initialBalances ...*big.Int) GoBalance {
 	return balances
 }
 
-// SumGoAccountBalances sums the balances of a list of GoAccounts and panics on negative functions.
+// SumGoAccountBalances sums the balances of a list of GoAccounts and panics on negative balances.
 // This panic is because any circuit that is passed negative balances will violate constraints.
 func SumGoAccountBalances(accounts []GoAccount) GoBalance {
 	assetSum := ConstructGoBalance()

--- a/cli/verify.go
+++ b/cli/verify.go
@@ -10,7 +10,7 @@ import (
 
 var verifyCmd = &cobra.Command{
 	Use:   "verify [BatchCount]",
-	Short: "Performs full verification of using the public data in 'out/public/' and the user data in 'out/secret/'",
+	Short: "Performs full verification using the public data in 'out/public/' and the user data in 'out/secret/'",
 	Long: "Performs full verification of all generated proofs using the public data in 'out/public/' and the user data in 'out/secret/'.\n" +
 		"Intended to be used after proof generation to validate the proofs were generated correctly. Verifies: \n" +
 		" 1) Each proof is valid (the zk-SNARK verification passes).\n" +

--- a/core/types.go
+++ b/core/types.go
@@ -25,7 +25,7 @@ type ProofElements struct {
 	MerkleRootWithAssetSumHash []byte
 }
 
-// RawProofElements is contains all the same items as ProofElements, except the accounts are RawGoAccounts
+// RawProofElements contains all the same items as ProofElements, except the accounts are RawGoAccounts
 // should be used when writing to a json file or reading directly from a json file.
 type RawProofElements struct {
 	Accounts                   []circuit.RawGoAccount


### PR DESCRIPTION
## Summary
Fix 6 typos/grammar issues across 4 files:
- `core/types.go`: Fix "is contains" → "contains" (copy-paste error in doc comment)
- `cli/verify.go`: Fix "verification of using" → "verification using" (broken grammar)
- `circuit/utils.go`: Fix "negative functions" → "negative balances" (wrong word)
- `README.md`: Fix "liabilites" → "liabilities" (misspelling)
- `README.md`: Fix "an mid-layer" → "a mid-layer" (wrong article)
- `README.md`: Fix "correponds" → "corresponds" (misspelling)

No functional changes — comments and documentation only.